### PR TITLE
Build By VS 2019

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
 	url = https://github.com/google/googletest.git
 [submodule "src/third_party/gyp"]
 	path = src/third_party/gyp
-	url = https://github.com/chromium/gyp.git
+	#url = https://github.com/chromium/gyp.git
+	url = https://github.com/i13302/gyp.git
 [submodule "src/third_party/japanese_usage_dictionary"]
 	path = src/third_party/japanese_usage_dictionary
 	url = https://github.com/hiroyuki-komatsu/japanese-usage-dictionary.git

--- a/Install-Guide.md
+++ b/Install-Guide.md
@@ -1,0 +1,67 @@
+# インストールを確認
+
+## マシン
+- OS 名	Microsoft Windows 10 Education
+- バージョン	10.0.19044 ビルド 19044
+- システムの種類	x64-ベース PC
+- システムモデル	VirtualBox
+
+## コンパイル
+- Visual Studo 2019 Community
+```コンポーネント(まだ減らせるかも)
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.VC.CoreIde",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.CMake",
+    "Microsoft.VisualStudio.Component.VC.CMake.Project",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.ATLMFC",
+    "Microsoft.Component.VC.Runtime.UCRTSDK",
+    "Microsoft.VisualStudio.Workload.NativeDesktop"
+  ]
+```
+- Qt 5.15.2 MSVC2019 32bit
+- Python 3.10.6
+
+## env path
+- `C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86`
+`mt.exe`と`rc.exe`がビルドに必要なようなので，`C:\Program Files (x86)\Windows Kits\10\bin\`配下にVSのコンポーネントに合わせたディレクトリが生成されている．
+当該ファイルがあるコンポーネントを選び，`PATH`を設定する．
+
+- `C:\Work\depot_tools`
+Pythonを別途インストールするのなら，Gitぐらいしか使わない．
+なお，本ツールのPythonでは文字コード周りにエラー(警告かも？)が出るようだ．
+
+## 実行コマンド
+```
+cd C:\Work\mozc\src
+chcp 932
+python build_mozc.py gyp --qtdir=C:\Qt\5.15.2\msvc2019
+python build_mozc.py build -c Release package >> %homepath%\Desktop\log-11.log
+```
+
+```
+python build_mozc.py clean
+```
+
+## 原本から変更したソース
+- `C:\Work\mozc\src\third_party\gyp\pylib\gyp\win_tool.py`
+	- UTF-8 with BOMへの対応
+- `C:\Work\mozc\src\build_mozc.py`
+	- VS2017を探してエラーを吐くため，VS2019に書き換えた．
+	- 将来的に，同じ理由で書き換えが必要である．
+
+## memo
+VSを用いてコンパイルするため，`Developer Command Prompt for VS 2019`を用いる．
+

--- a/src/install-Win64-with-Qt.bat
+++ b/src/install-Win64-with-Qt.bat
@@ -1,0 +1,30 @@
+echo 'Install Mozc With Qt'
+
+echo 'Install Mozc (64-bit)'
+copy out_win\Release\mozc_broker32.exe             %ProgramFiles(x86)%\Mozc
+copy out_win\Release\mozc_cache_service.exe        %ProgramFiles(x86)%\Mozc
+copy out_win\Release\mozc_renderer.exe             %ProgramFiles(x86)%\Mozc
+copy out_win\Release\mozc_server.exe               %ProgramFiles(x86)%\Mozc
+
+mkdir %ProgramFiles(x86)%\Mozc\platforms
+copy out_win\ReleaseDynamic\mozc_tool.exe          %ProgramFiles(x86)%\Mozc
+copy out_win\ReleaseDynamic\Qt5Core.dll            %ProgramFiles(x86)%\Mozc
+copy out_win\ReleaseDynamic\Qt5Gui.dll             %ProgramFiles(x86)%\Mozc
+copy out_win\ReleaseDynamic\Qt5Widgets.dll         %ProgramFiles(x86)%\Mozc
+copy out_win\ReleaseDynamic\platforms\qwindows.dll %ProgramFiles(x86)%\Mozc\platforms
+
+copy out_win\Release_x64\mozc_broker64.exe         %ProgramFiles(x86)%\Mozc
+
+echo 'Register Mozc for IMM32 into 64-bit environment
+copy out_win\Release_x64\mozc_ja.ime               %windir%\System32
+copy out_win\Release\mozc_ja.im                    %windir%\SysWOW64
+
+"%ProgramFiles(x86)%\Mozc\mozc_broker64.exe" --mode=register_ime
+
+echo 'Register Mozc for TSF into 64-bit environment'
+copy out_win\Release\mozc_ja_tip32.dll             %ProgramFiles(x86)%\Mozc
+copy out_win\Release_x64\mozc_ja_tip64.dll         %ProgramFiles(x86)%\Mozc
+
+regsvr32 "%ProgramFiles(x86)%\Mozc\mozc_ja_tip32.dll"
+regsvr32 "%ProgramFiles(x86)%\Mozc\mozc_ja_tip64.dll"
+

--- a/src/install-Win64-with-Qt.bat
+++ b/src/install-Win64-with-Qt.bat
@@ -20,7 +20,7 @@ copy out_win\Release_x64\mozc_broker64.exe         "%ProgramFiles(x86)%\Mozc"
 
 echo 'Register Mozc for IMM32 into 64-bit environment
 copy out_win\Release_x64\mozc_ja.ime               "%windir%\System32"
-copy out_win\Release\mozc_ja.im                    "%windir%\SysWOW64"
+copy out_win\Release\mozc_ja.ime                   "%windir%\SysWOW64"
 
 "%ProgramFiles(x86)%\Mozc\mozc_broker64.exe" --mode=register_ime
 

--- a/src/install-Win64-with-Qt.bat
+++ b/src/install-Win64-with-Qt.bat
@@ -1,29 +1,32 @@
 echo 'Install Mozc With Qt'
 
+cd %~dp0
+mkdir "%ProgramFiles(x86)%\Mozc"
+
 echo 'Install Mozc (64-bit)'
-copy out_win\Release\mozc_broker32.exe             %ProgramFiles(x86)%\Mozc
-copy out_win\Release\mozc_cache_service.exe        %ProgramFiles(x86)%\Mozc
-copy out_win\Release\mozc_renderer.exe             %ProgramFiles(x86)%\Mozc
-copy out_win\Release\mozc_server.exe               %ProgramFiles(x86)%\Mozc
+copy out_win\Release\mozc_broker32.exe             "%ProgramFiles(x86)%\Mozc"
+copy out_win\Release\mozc_cache_service.exe        "%ProgramFiles(x86)%\Mozc"
+copy out_win\Release\mozc_renderer.exe             "%ProgramFiles(x86)%\Mozc"
+copy out_win\Release\mozc_server.exe               "%ProgramFiles(x86)%\Mozc"
 
-mkdir %ProgramFiles(x86)%\Mozc\platforms
-copy out_win\ReleaseDynamic\mozc_tool.exe          %ProgramFiles(x86)%\Mozc
-copy out_win\ReleaseDynamic\Qt5Core.dll            %ProgramFiles(x86)%\Mozc
-copy out_win\ReleaseDynamic\Qt5Gui.dll             %ProgramFiles(x86)%\Mozc
-copy out_win\ReleaseDynamic\Qt5Widgets.dll         %ProgramFiles(x86)%\Mozc
-copy out_win\ReleaseDynamic\platforms\qwindows.dll %ProgramFiles(x86)%\Mozc\platforms
+mkdir "%ProgramFiles(x86)%\Mozc\platforms"
+copy out_win\ReleaseDynamic\mozc_tool.exe          "%ProgramFiles(x86)%\Mozc"
+copy out_win\ReleaseDynamic\Qt5Core.dll            "%ProgramFiles(x86)%\Mozc"
+copy out_win\ReleaseDynamic\Qt5Gui.dll             "%ProgramFiles(x86)%\Mozc"
+copy out_win\ReleaseDynamic\Qt5Widgets.dll         "%ProgramFiles(x86)%\Mozc"
+copy out_win\ReleaseDynamic\platforms\qwindows.dll "%ProgramFiles(x86)%\Mozc\platforms"
 
-copy out_win\Release_x64\mozc_broker64.exe         %ProgramFiles(x86)%\Mozc
+copy out_win\Release_x64\mozc_broker64.exe         "%ProgramFiles(x86)%\Mozc"
 
 echo 'Register Mozc for IMM32 into 64-bit environment
-copy out_win\Release_x64\mozc_ja.ime               %windir%\System32
-copy out_win\Release\mozc_ja.im                    %windir%\SysWOW64
+copy out_win\Release_x64\mozc_ja.ime               "%windir%\System32"
+copy out_win\Release\mozc_ja.im                    "%windir%\SysWOW64"
 
 "%ProgramFiles(x86)%\Mozc\mozc_broker64.exe" --mode=register_ime
 
 echo 'Register Mozc for TSF into 64-bit environment'
-copy out_win\Release\mozc_ja_tip32.dll             %ProgramFiles(x86)%\Mozc
-copy out_win\Release_x64\mozc_ja_tip64.dll         %ProgramFiles(x86)%\Mozc
+copy out_win\Release\mozc_ja_tip32.dll             "%ProgramFiles(x86)%\Mozc"
+copy out_win\Release_x64\mozc_ja_tip64.dll         "%ProgramFiles(x86)%\Mozc"
 
 regsvr32 "%ProgramFiles(x86)%\Mozc\mozc_ja_tip32.dll"
 regsvr32 "%ProgramFiles(x86)%\Mozc\mozc_ja_tip64.dll"

--- a/src/uninstall-Win64-with-Qt.bat
+++ b/src/uninstall-Win64-with-Qt.bat
@@ -1,0 +1,11 @@
+echo 'Uninstall Mozc With Qt'
+
+"%ProgramFiles(x86)%\Mozc\mozc_broker64.exe" --mode=unregister_ime
+del /q "%windir%\System32\mozc_ja.ime"
+del /q "%windir%\SysWOW64\mozc_ja.ime"
+
+regsvr32 /u "%ProgramFiles(x86)%\Mozc\mozc_ja_tip32.dll"
+regsvr32 /u "%ProgramFiles(x86)%\Mozc\mozc_ja_tip64.dll"
+
+del /s /q "%ProgramFiles(x86)%\Mozc\"
+rmdir /s /q "%ProgramFiles(x86)%\Mozc\"


### PR DESCRIPTION
**Pull requests to the Mozc project are limited to the specific directories.**

Files and directories we may accept pull requests:
* files in the [top directory](https://github.com/google/mozc/tree/master/)
* [.github/](https://github.com/google/mozc/tree/master/.github/)
* [docker/](https://github.com/google/mozc/tree/master/docker/)
* [docs/](https://github.com/google/mozc/tree/master/docs/)
* [src/.bazelrc](https://github.com/google/mozc/tree/master/src/.bazelrc)
* [src/BUILD.(library).bazel](https://github.com/google/mozc/tree/master/src/)
* [src/data/oss/](https://github.com/google/mozc/tree/master/src/data/oss/)
* [src/data/test/quality_regression_test/](https://github.com/google/mozc/tree/master/src/data/test/quality_regression_test/)
* [src/unix/emacs/mozc.el](https://github.com/google/mozc/tree/master/src/unix/emacs/mozc.el)
* [src/WORKSPACE.bazel](https://github.com/google/mozc/tree/master/src/WORKSPAE.bazel)

Although Google company policy certainly allows Mozc team to accept pull
requests, to do so Mozc team needs to move all Mozc source files into
`third_party` directory in the Google internal source repository [1].
Doing that without breaking any Google internal project that depends on
Mozc source code requires non-trivial amount of time and engineering
resources that Mozc team cannot afford right now.

Mozc team continues to seek opportunities to address this limitation,
but we are still not ready to accept any pull request due to the above
reason.

[1]: [Open Source at Google - Linuxcon 2016](http://events.linuxfoundation.org/sites/events/files/slides/OSS_at_Google.pdf#page=30)
> ### License Compliance
> - We store all external open source code in a third_party hierarchy,
> along with the licenses for each project. We only allow the use of OSS
> under licenses we can comply with.
> - Use of external open source is not allowed unless it is put in that
> third_party tree.
> - This makes it easier to ensure we are only using software with
licenses that we can abide.
> - This also allows us to generate a list of all licenses used by any
project we build when they are released externally.
